### PR TITLE
fixed deprecated modules for using scipy v1.13.0

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -34,10 +34,9 @@ from vlstools.slip_detection import slippage_worker
 
 
 __author__ = "Theodore (Ted) B. Verhey"
-__version__ = "5.0"
+__version__ = "5.0.1"
 __email__ = "verheytb@gmail.com"
 __status__ = "Production"
-
 
 class Database(object):
     def __init__(self, user_working=os.path.expanduser("~/.vastdb")):

--- a/vlstools/switch_detection.py
+++ b/vlstools/switch_detection.py
@@ -1,7 +1,7 @@
 
 import multiprocessing
 from itertools import combinations, product
-from scipy.misc import comb
+from scipy.special import comb
 from .alignments import is_subset
 from .utils import Counter, tprint, chunk_combinations, is_sublist
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/mf019/bin/vast", line 32, in <module>
    from vlstools.switch_detection import switches_worker
  File "/home/mf019/vast/vlstools/switch_detection.py", line 4, in <module>
    from scipy.misc import comb
ImportError: cannot import name 'comb' from 'scipy.misc' (/home/mf019/miniconda3/lib/python3.12/site-packages/scipy/misc/__init__.py)
```

importing comb from scipy.misc fails as scipy.misc has been deprecated since scipy v1.10.0. comb is now located under scipy.special.

also bumped version by 0.0.1. -mjf :)